### PR TITLE
基盤モジュール群の不具合修正

### DIFF
--- a/Scripts/Modules/Cache/Cache.cs
+++ b/Scripts/Modules/Cache/Cache.cs
@@ -110,7 +110,7 @@ namespace Modules.Cache
 		{
 			lock (cacheReference)
 			{
-				cacheReference[referenceName] = new Reference();
+				cacheReference[referenceName] = new Reference() { referenceCount = 1 };
 			}
 
 			return cacheReference[referenceName];
@@ -138,7 +138,7 @@ namespace Modules.Cache
 
             var instance = GetInstance();
 
-            if (!instance.cache.ContainsKey(key))
+            if (instance.cache.ContainsKey(key))
             {
                 instance.cache.Remove(key);
             }
@@ -178,7 +178,7 @@ namespace Modules.Cache
 
             if (instance.cache == null) { return false; }
 
-            return instance.Keys.Contains(key);
+            return instance.cache.ContainsKey(key);
         }
 
         private Cache<T> GetInstance()

--- a/Scripts/Modules/FileCache/FileCacheManagerBase.cs
+++ b/Scripts/Modules/FileCache/FileCacheManagerBase.cs
@@ -120,6 +120,8 @@ namespace Modules.FileCache
 
             var cacheData = LocalDataManager.Get<CacheData>();
             
+            var changed = false;
+
             foreach (var fileData in cacheData.files)
             {
                 var fileName = GetFileName(fileData.Source);
@@ -131,6 +133,15 @@ namespace Modules.FileCache
                 if (fileData.Alive()){ continue; }
 
                 File.Delete(filePath);
+
+                changed = true;
+            }
+
+            if (changed)
+            {
+                cacheData.files = cacheData.files.Where(x => x.Alive()).ToArray();
+
+                cacheData.Save();
             }
         }
 

--- a/Scripts/Modules/ObjectPool/ObjectPool.cs
+++ b/Scripts/Modules/ObjectPool/ObjectPool.cs
@@ -93,10 +93,6 @@ namespace Modules.ObjectPool
             // キャッシュ済み.
             if (cachedObjects.Contains(target)) { return; }
 
-            if (UnityUtility.IsNull(target)) { return; }
-
-            if (UnityUtility.IsNull(instance)) { return; }
-
             UnityUtility.SetParent(target.gameObject, instance);
                 
             target.transform.Reset();

--- a/Scripts/Modules/Sound/CriWare/SoundManagementBase.cs
+++ b/Scripts/Modules/Sound/CriWare/SoundManagementBase.cs
@@ -488,7 +488,7 @@ namespace Modules.Sound
 
         private void ReleaseSoundSheet()
         {
-            for (var i = 0; i < soundElements.Count; ++i)
+            for (var i = soundElements.Count - 1; i >= 0; --i)
             {
                 var soundElement = soundElements[i];
 

--- a/Scripts/Modules/StateControl/StateController.cs
+++ b/Scripts/Modules/StateControl/StateController.cs
@@ -122,7 +122,7 @@ namespace Modules.StateControl
 
 			var changeStateInfo = new ChangeStateInfo()
 			{
-				from = prevNode.State, 
+				from = prevNode != null ? prevNode.State : default,
 				to = nextNode.State
 			};
 

--- a/Scripts/Modules/Window/Window.cs
+++ b/Scripts/Modules/Window/Window.cs
@@ -125,12 +125,12 @@ namespace Modules.Window
                 onClose.OnNext(Unit.Default);
             }
                         
+            Status = WindowStatus.Closed;
+
             if (deleteOnClose)
             {
                 UnityUtility.SafeDelete(gameObject);
             }
-
-            Status = WindowStatus.Closed;
         }
 
         public async UniTask Wait()


### PR DESCRIPTION
- Cache: Remove の ContainsKey 条件が逆だったバグを修正
- Cache: CreateNewReference で referenceCount の初期値が 0 のままだったバグを修正
- Cache: HasCache を Keys.Contains(O(n)) から cache.ContainsKey(O(1)) に改善
- StateController: 初回ステート変更時に prevNode が null で NullReferenceException が発生するバグを修正
- SoundManagementBase: ReleaseSoundSheet でリスト順方向イテレーション中に RemoveAt していたため要素がスキップされるバグを修正（後ろから走査に変更）
- FileCacheManagerBase: CleanExpiredFiles でファイル削除後に cacheData のエントリ削除と保存が行われていなかったバグを修正
- Window: deleteOnClose=true 時に SafeDelete の後に Status を設定していたため、Closed 状態が正しく反映されないバグを修正
- ObjectPool: Release メソッド内の重複した null チェックを削除