### PR TITLE
OnErrorRetry 拡張メソッド追加、IObservable→Observable 修正、using 不足修正

### DIFF
--- a/Scripts/Extensions/Methods/UniTaskExtensions.cs
+++ b/Scripts/Extensions/Methods/UniTaskExtensions.cs
@@ -71,6 +71,56 @@ namespace Extensions
 			return source.Do(onCompleted: _ => finallyAction());
 		}
 
+		//----- Retry -----
+
+		public static Observable<T> OnErrorRetry<T, TException>(
+			this Observable<T> source,
+			Action<TException> onError,
+			int retryMaxCount,
+			float retryDelay) where TException : Exception
+		{
+			return OnErrorRetry(source, onError, retryMaxCount, TimeSpan.FromSeconds(retryDelay));
+		}
+
+		public static Observable<T> OnErrorRetry<T, TException>(
+			this Observable<T> source,
+			Action<TException> onError,
+			int retryMaxCount,
+			TimeSpan retryDelay) where TException : Exception
+		{
+			return Observable.Create<T>((observer, ct) =>
+			{
+				var retryCount = 0;
+
+				void Subscribe()
+				{
+					source.Subscribe(
+						onNext: value => observer.OnNext(value),
+						onErrorResume: ex =>
+						{
+							if (ex is TException tex && retryCount < retryMaxCount)
+							{
+								retryCount++;
+								onError(tex);
+								Observable.Timer(retryDelay, TimeProvider.System)
+									.Subscribe(_ => Subscribe())
+									.RegisterTo(ct);
+							}
+							else
+							{
+								observer.OnCompleted(Result.Failure(ex));
+							}
+						},
+						onCompleted: result => observer.OnCompleted(result))
+					.RegisterTo(ct);
+				}
+
+				Subscribe();
+
+				return default;
+			});
+		}
+
 		//----- Conversion -----
 
 		public static Observable<Unit> AsUnitObservable<T>(this Observable<T> source)
@@ -78,9 +128,9 @@ namespace Extensions
 			return source.Select(_ => Unit.Default);
 		}
 
-		public static UniTask<T> ToUniTask<T>(this Observable<T> observable, CancellationToken cancellationToken = default)
+		public static async UniTask<T> ToUniTask<T>(this Observable<T> observable, CancellationToken cancellationToken = default)
 		{
-			return observable.FirstAsync(cancellationToken);
+			return await observable.FirstAsync(cancellationToken);
 		}
 
 		public static async UniTask ToUniTask(this Observable<Unit> observable, CancellationToken cancellationToken = default)
@@ -92,12 +142,12 @@ namespace Extensions
 
 		public static void Forget(this UniTask task, Component component)
 		{
-			task.ToObservable().Subscribe(_ => { }).AddTo(component);
+			task.AttachExternalCancellation(component.GetCancellationTokenOnDestroy()).Forget();
 		}
 
 		public static void Forget(this UniTask task, GameObject gameObject)
 		{
-			task.ToObservable().Subscribe(_ => { }).AddTo(gameObject);
+			task.AttachExternalCancellation(gameObject.GetCancellationTokenOnDestroy()).Forget();
 		}
 	}
 }

--- a/Scripts/Modules/Scene/SceneManagerBase.cs
+++ b/Scripts/Modules/Scene/SceneManagerBase.cs
@@ -772,8 +772,7 @@ namespace Modules.Scene
 
             if (observable == null)
             {
-                observable = LoadSceneCore(identifier, mode)
-                    .ToObservable()
+                observable = Observable.FromAsync(async ct => await LoadSceneCore(identifier, mode))
                     .Do(_ => loadingScenes.Remove(identifier))
                     .Share();
 
@@ -983,9 +982,7 @@ namespace Modules.Scene
 
             if (observable == null)
             {
-                observable = UnloadSceneCore(sceneInstance)
-                    .ToObservable()
-                    .Select(_ => Unit.Default)
+                observable = Observable.FromAsync(async ct => { await UnloadSceneCore(sceneInstance); return Unit.Default; })
                     .Do(_ => unloadingScenes.Remove(identifier))
                     .Share();
 

--- a/Scripts/Modules/UI/Extension/UIRawImage.cs
+++ b/Scripts/Modules/UI/Extension/UIRawImage.cs
@@ -2,6 +2,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.UI;
+using Extensions;
 using R3;
 
 namespace Modules.UI.Extension

--- a/Scripts/Modules/UI/ScreenRotation/RotationRoot.cs
+++ b/Scripts/Modules/UI/ScreenRotation/RotationRoot.cs
@@ -1,6 +1,7 @@
 
 using UnityEngine;
 using UnityEngine.UI;
+using Extensions;
 using Extensions.Serialize;
 using R3;
 


### PR DESCRIPTION
- OnErrorRetry<T, TException> を拡張メソッドとして実装（R3 には存在しない）
- ToUniTask を async/await でラップ（Task→UniTask 変換エラー修正）
- Forget を CancellationToken ベースに変更（IObservable<AsyncUnit> 問題回避）
- SceneManagerBase: .ToObservable() → Observable.FromAsync() に修正
- RotationRoot, UIRawImage: using Extensions 追加